### PR TITLE
fix: mcv_rss error when webrender is not available

### DIFF
--- a/schedulers/mcv_rss.py
+++ b/schedulers/mcv_rss.py
@@ -42,7 +42,7 @@ async def get_article(version):
     if not link:
         link = 'https://www.minecraft.net/en-us/article/minecraft-java-edition-' + re.sub("\\.", "-", version)
     if not web_render:
-        return
+        return '', ''
     get = web_render + 'source?url=' + quote(link)
 
     try:


### PR DESCRIPTION
![image](https://github.com/Teahouse-Studios/akari-bot/assets/46394906/e4f724c5-dc2f-43cd-a0cd-dd3444a39959)
