### PR TITLE
fix: mcv_rss error when webrender is not available

### DIFF
--- a/schedulers/mcv_rss.py
+++ b/schedulers/mcv_rss.py
@@ -42,7 +42,7 @@ async def get_article(version):
     if not link:
         link = 'https://www.minecraft.net/en-us/article/minecraft-java-edition-' + re.sub("\\.", "-", version)
     if not web_render:
-        return
+        return '', ''
     get = web_render + 'source?url=' + quote(link)
 
     try:


### PR DESCRIPTION
![image](https://github.com/Teahouse-Studios/akari-bot/assets/46394906/14545f89-b3b2-4c74-bed3-09b5b47ab4af)

Follow-up #956
