### PR TITLE
fix(su_utils.py): add temp variables.

### DIFF
--- a/modules/core/locales/zh_cn.json
+++ b/modules/core/locales/zh_cn.json
@@ -57,6 +57,8 @@
     "core.message.alias.remove.success": "已移除自定义命令别名：${arg1}",
     "core.message.alias.reset.success": "已重置自定义命令别名列表。",
     "core.message.confirm": "你确定吗？",
+    "core.message.update.failed": "更新代码失败，请检查控制台报错信息。\n依赖更新因以上报错中止。",
+    "core.message.update.restart.failed": "重启时更新代码失败，请检查控制台报错信息。\n依赖更新因以上报错中止。",
     "core.message.forward_msg.disable": "已关闭转发消息。",
     "core.message.forward_msg.enable": "已开启转发消息。",
     "core.message.leave.confirm": "你确定吗？此操作不可逆。",

--- a/modules/core/su_utils.py
+++ b/modules/core/su_utils.py
@@ -315,9 +315,13 @@ async def update_bot(msg: Bot.MessageSession):
     await msg.send_message(msg.locale.t("core.message.confirm"))
     confirm = await msg.wait_confirm()
     if confirm:
-        await msg.send_message(pull_repo())
-        await msg.send_message(update_dependencies())
-
+        pull_repo_result = pull_repo()
+        if pull_repo_result != '':
+            await msg.send_message(pull_repo_result)
+            await msg.send_message(update_dependencies())
+        else:
+            await msg.send_message(msg.locale.t("core.message.update.failed"))
+            
 
 if Info.subprocess:
     upds = module('update&restart', developers=['OasisAkari'], required_superuser=True, alias='u&r', base=True)
@@ -330,8 +334,12 @@ if Info.subprocess:
             restart_time.append(datetime.now().timestamp())
             await wait_for_restart(msg)
             write_version_cache(msg)
-            await msg.send_message(pull_repo())
-            await msg.send_message(update_dependencies())
+            pull_repo_result = pull_repo()
+            if pull_repo_result != '':
+                await msg.send_message(pull_repo_result)
+                await msg.send_message(update_dependencies())
+            else:
+                await msg.send_message(msg.locale.t("core.message.update.restart.failed"))
             restart()
 
 if Bot.FetchTarget.name == 'QQ':


### PR DESCRIPTION
为`~update`及`~update&restart`添加对`pull_repo()`的非空判断，适用于因网络波动导致的更新失败提示。