### PR TITLE
fix: add m.mentions to all matrix rich replies

### DIFF
--- a/bots/matrix/message.py
+++ b/bots/matrix/message.py
@@ -51,8 +51,10 @@ class MessageSession(MessageSessionT):
         send: list[nio.RoomSendResponse] = []
         for x in message_chain.as_sendable(embed=False):
             reply_to = None
+            reply_to_user = None
             if quote and len(send) == 0:
                 reply_to = self.target.message_id
+                reply_to_user = self.session.sender
 
             if isinstance(x, Plain):
                 content = {
@@ -142,6 +144,10 @@ class MessageSession(MessageSessionT):
                         'event_id': reply_to
                     }
                 }
+                # mention target user
+                content['m.mentions'] = {
+                    'user_ids': [reply_to_user]
+                }
 
             resp = await bot.room_send(self.session.target, 'm.room.message', content, ignore_unverified_devices=True)
             if 'status_code' in resp.__dict__:
@@ -187,7 +193,6 @@ class MessageSession(MessageSessionT):
         elif msgtype == 'm.audio':
             url = str(content['url'])
             return MessageChain(Voice(await bot.mxc_to_http(url)))
-            pass
         Logger.error(f"Got unknown msgtype: {msgtype}")
         return MessageChain([])
 


### PR DESCRIPTION
Some clients still show red-circle notifications when rich-reply messages are received but sometimes the events may be skipped. Matrix spec says it is "desirable" to add user mentions to rich-reply messages. Element, SchindiChat uses this but Cinny doesn't.
<https://github.com/cinnyapp/cinny/issues/1544>