### PR TITLE
[FEATURE]增加Actions自动部署环境更新依赖文件

### DIFF
--- a/.github/workflows/update-poetry-dependencies.yml
+++ b/.github/workflows/update-poetry-dependencies.yml
@@ -1,0 +1,67 @@
+name: Update Poetry Dependencies
+
+on:
+  workflow_dispatch:
+
+permissions:  
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-branch-exists:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Check if update-deps branch exists
+        id: check_branch
+        run: |
+          echo "Checking for 'update-deps' branch..."
+          if [ -z "$(git ls-remote --heads origin update-deps)" ]; then
+            echo "Branch 'update-deps' does not exist. Continuing workflow."
+          else
+            echo "分支 'update-deps' 已存在，请删除后执行本工作流。" && exit 1
+          fi
+
+  update-dependencies:
+    runs-on: ubuntu-latest
+    needs: check-branch-exists
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Poetry
+        run: |
+          curl -sSL "https://install.python-poetry.org" | python3 -
+
+      - name: Update Dependencies
+        run: |
+          poetry update
+
+      - name: Update requirements.txt
+        run: |
+          poetry export -f requirements.txt --output requirements.txt
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git checkout -b update-deps
+          git add .
+          git commit -m "Update dependencies"
+          git push origin update-deps
+
+  create-pull-request:
+    runs-on: ubuntu-latest
+    needs: update-dependencies
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: update-deps
+      - name: Create Pull Request
+        run: |
+          gh pr create --title "Poetry依赖自动更新" --body "本Pull Request为手动运行的用于更新由Poetry管理的依赖。<br/>**注意：请在合并后同时删除update-deps分支，否则下次的自动更新依赖将不会运行。**" --base master --head update-deps

--- a/.github/workflows/update-poetry-dependencies.yml
+++ b/.github/workflows/update-poetry-dependencies.yml
@@ -1,7 +1,8 @@
 name: Update Poetry Dependencies
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 
 permissions:  
   contents: write

--- a/.github/workflows/update-poetry-dependencies.yml
+++ b/.github/workflows/update-poetry-dependencies.yml
@@ -3,6 +3,7 @@ name: Update Poetry Dependencies
 on:
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 permissions:  
   contents: write


### PR DESCRIPTION
## 说明
本 Action 工作流文件已经过测试，基本保证目标功能正常。
## 工作流详情
### 运行时间
本工作流将默认在周日00:00运行，也可以使用 `workflow_dispatch:` 手动运行
### 具体流程
本工作流分为3个步骤：
#### 检查分支存在情况
由于本工作流需要创建用于更新依赖的分支 `update-deps` ，故本工作流将先检查此分支是否存在，若存在则退出本工作流，若不存在则继续下面的工作。
#### 更新依赖
1. 环境安装
2. 执行 `poetry update`
3. 执行 `poetry export -f requirements.txt --output requirements.txt`
4. 将修改提交至 `update-deps` 
#### 开启Pull Request
`update-deps` 分支创建后，将利用GitHub CLI创建一个简单的PR，开发者可根据需要进行合并。
## 需要权限
目标仓库需要打开设置中的以下权限：
- [x] Read and write permissions
- [x] Allow GitHub Actions to create and approve pull requests
## 其他注意事项
- 本工作流理论上可适用于所有使用Poetry部署的项目，如有缺陷欢迎斧正。
- **现阶段请在合并对应PR后删除update-deps分支，若不删除则会影响下一次工作流运行**

