### PR TITLE
Fix code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/bots/api/bot.py
+++ b/bots/api/bot.py
@@ -241,7 +241,9 @@ async def get_config_file(cfg_filename: str):
         raise HTTPException(status_code=404, detail="not found")
     if not cfg_filename.endswith(".toml"):
         raise HTTPException(status_code=400, detail="bad request")
-    cfg_file_path = os.path.join(config_path, cfg_filename)
+    cfg_file_path = os.path.normpath(os.path.join(config_path, cfg_filename))
+    if not cfg_file_path.startswith(config_path):
+        raise HTTPException(status_code=400, detail="bad request")
 
     try:
         with open(cfg_file_path, 'r', encoding='UTF-8') as f:
@@ -260,7 +262,9 @@ async def edit_config_file(cfg_filename: str, request: Request):
         raise HTTPException(status_code=404, detail="not found")
     if not cfg_filename.endswith(".toml"):
         raise HTTPException(status_code=400, detail="bad request")
-    cfg_file_path = os.path.join(config_path, cfg_filename)
+    cfg_file_path = os.path.normpath(os.path.join(config_path, cfg_filename))
+    if not cfg_file_path.startswith(config_path):
+        raise HTTPException(status_code=400, detail="bad request")
     try:
         body = await request.json()
         content = body["content"]


### PR DESCRIPTION
Fixes [https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/33](https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/33)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder (`config_path`). This will prevent path traversal attacks by ensuring that the user cannot escape the designated directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
