### PR TITLE
Potential fix for code scanning alert no. 57: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/core/database/local.py
+++ b/core/database/local.py
@@ -95,8 +95,8 @@ class CrowdinActivityRecords:
     @retry(stop=stop_after_attempt(3))
     @auto_rollback_error
     def check(txt: str):
-        query_hash = hashlib.md5(
-            txt.encode(encoding="UTF-8"), usedforsecurity=False
+        query_hash = hashlib.sha256(
+            txt.encode(encoding="UTF-8")
         ).hexdigest()
         query = (
             session.query(CrowdinActivityRecordsTable)


### PR DESCRIPTION
Potential fix for [https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/57](https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/57)

To fix the problem, we need to replace the weak MD5 hashing algorithm with a stronger, modern cryptographic hash function. In this case, SHA-256 is a suitable replacement as it is a strong cryptographic hashing function resistant to collision and pre-image attacks.

The changes required are:
1. Replace the `hashlib.md5` function with `hashlib.sha256`.
2. Update the `CrowdinActivityRecords.check` method to use SHA-256 instead of MD5.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
