### PR TITLE
Potential fix for code scanning alert no. 67: Uncontrolled data used in path expression

### DIFF
--- a/bots/web/bot.py
+++ b/bots/web/bot.py
@@ -888,8 +888,8 @@ async def redirect_root(path=None):
         return RedirectResponse(url="/webui")
     if path.startswith("/api") or path.startswith("/webui"):
         return RedirectResponse(url=path)
-    static_path = os.path.join(webui_path, path)
-    if not os.path.exists(static_path):
+    static_path = os.path.normpath(os.path.join(webui_path, path))
+    if not static_path.startswith(webui_path) or not os.path.exists(static_path):
         raise HTTPException(status_code=404, detail="Not found")
     return FileResponse(static_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/67](https://github.com/Teahouse-Studios/akari-bot/security/code-scanning/67)

To fix the issue, we need to ensure that the constructed `static_path` is contained within the intended root directory (`webui_path`). This can be achieved by normalizing the path using `os.path.normpath` and verifying that the resulting path starts with `webui_path`. If the normalized path does not start with `webui_path`, we should raise an exception or return a 404 error.

Steps to fix:
1. Normalize the constructed path using `os.path.normpath`.
2. Check if the normalized path starts with the intended root directory (`webui_path`).
3. If the check fails, raise an `HTTPException` with a 404 status code.
4. If the check passes, proceed with serving the file using `FileResponse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
