### PR TITLE
[FEATURE]: Mojang服务状态检测

### DIFF
--- a/core/builtins/converter/__init__.py
+++ b/core/builtins/converter/__init__.py
@@ -45,6 +45,7 @@ converter.register_unstructure_hook(
     },
 )
 
+
 # 会话信息的反结构化处理
 # 将 TargetInfo 对象转换为字典，由于序列化需要从数据库重新异步获取，只保留 _type 和 target_id 字段
 converter.register_unstructure_hook(TargetInfo, lambda obj: {"_type": type(obj).__name__, "target_id": obj.target_id})

--- a/modules/mojang_status/__init__.py
+++ b/modules/mojang_status/__init__.py
@@ -6,24 +6,28 @@ from core.component import module
 from core.utils.http import get_url
 
 mojang_status = module(
-    "mojang_status", desc="{I18N:mojang_status.help.desc}", alias="mcstatus", developers=["Don_Trueno"]
+    "mojang_status", desc="{I18N:mojang_status.help.desc}", alias=["mcstatus", "mjs", "mjsb"], developers=["Don_Trueno"]
 )
-
-MOJANG_SERVICES_ID = ["sessions", "api", "textures", "website", "accounts", "microsoft"]
 
 
 @mojang_status.command()
 async def _(msg: Bot.MessageSession):
+    msg_list = [
+        I18NContext(
+            "mojang_status.message.status",
+        )
+    ]
     try:  # https://www.mcstate.net/docs#api-mojang-status
         data = orjson.loads(await get_url("https://www.mcstate.net/api/mojang-status", 200))
-        msg_list = []
-        for id in MOJANG_SERVICES_ID:
-            status = data["services"][id]["status"]
-            msg_list.append(I18NContext("mojang_status.message.status.each", api=id, status=status))
-        message1 = "\n".join(msg_list)
+        for service in data.get("services", []):
+            msg_list.append(
+                I18NContext(
+                    "mojang_status.message.status.each", api=service.get("label", ""), status=service.get("status", "")
+                )
+            )
     except ValueError as e:
         if str(e).startswith("429"):
-            message1 = msg.session_info.locale.t("mojang_status.message.failed")
+            msg_list.append(I18NContext("mojang_status.message.failed"))
         else:
             raise e
-    return I18NContext("mojang_status.message.status", statuses=message1)
+    await msg.finish(msg_list)

--- a/modules/mojang_status/__init__.py
+++ b/modules/mojang_status/__init__.py
@@ -1,0 +1,29 @@
+import orjson
+
+from core.builtins.bot import Bot
+from core.builtins.message.internal import I18NContext
+from core.component import module
+from core.utils.http import get_url
+
+mojang_status = module(
+    "mojang_status", desc="{I18N:mojang_status.help.desc}", alias="mcstatus", developers=["Don_Trueno"]
+)
+
+MOJANG_SERVICES_ID = ["sessions", "api", "textures", "website", "accounts", "microsoft"]
+
+
+@mojang_status.command()
+async def _(msg: Bot.MessageSession):
+    try:  # https://www.mcstate.net/docs#api-mojang-status
+        data = orjson.loads(await get_url("https://www.mcstate.net/api/mojang-status", 200))
+        msg_list = []
+        for id in MOJANG_SERVICES_ID:
+            status = data["services"][id]["status"]
+            msg_list.append(I18NContext("mojang_status.message.status.each", api=id, status=status))
+        message1 = "\n".join(msg_list)
+    except ValueError as e:
+        if str(e).startswith("429"):
+            message1 = msg.session_info.locale.t("mojang_status.message.failed")
+        else:
+            raise e
+    return I18NContext("mojang_status.message.status", statuses=message1)

--- a/modules/mojang_status/locales/en_us.json
+++ b/modules/mojang_status/locales/en_us.json
@@ -1,7 +1,7 @@
 {
     "mojang_status.help.desc": "Inspect the real-time status of Mojang and Minecraft backend services.",
 
-    "mojang_status.message.status": "Real-time Mojang Statuses: \n${statuses}",
+    "mojang_status.message.status": "Real-time Mojang Statuses: \n",
     "mojang_status.message.status.each": "${api}: ${status}",
     "mojang_status.message.failed": "Fail to fetch, try again later.",
 

--- a/modules/mojang_status/locales/en_us.json
+++ b/modules/mojang_status/locales/en_us.json
@@ -1,0 +1,20 @@
+{
+    "mojang_status.help.desc": "Inspect the real-time status of Mojang and Minecraft backend services.",
+
+    "mojang_status.message.status": "Real-time Mojang Statuses: \n${statuses}",
+    "mojang_status.message.status.each": "${api}: ${status}",
+    "mojang_status.message.failed": "Fail to fetch, try again later.",
+
+    "mojang_status.service.sessions": "Session Server",
+    "mojang_status.service.sessions.desc": "Multiplayer authentication",
+    "mojang_status.service.api": "Mojang API",
+    "mojang_status.service.api.desc": "Player & name lookup",
+    "mojang_status.service.textures": "Textures",
+    "mojang_status.service.textures.desc": "Skins & capes",
+    "mojang_status.service.website": "Minecraft.net",
+    "mojang_status.service.website.desc": "Main website",
+    "mojang_status.service.accounts": "Accounts",
+    "mojang_status.service.accounts.desc": "Account management",
+    "mojang_status.service.microsoft": "Microsoft Auth",
+    "mojang_status.service.microsoft.desc": "Microsoft login (new auth)"
+}

--- a/modules/mojang_status/locales/zh_cn.json
+++ b/modules/mojang_status/locales/zh_cn.json
@@ -1,0 +1,20 @@
+{
+    "mojang_status.help.desc": "检查Mojang和Minecraft后端各服务的实时在线情况",
+
+    "mojang_status.message.status": "当前Mojang各服务状态：\n${statuses}",
+    "mojang_status.message.status.each": "${api}：${status}",
+    "mojang_status.message.failed": "获取失败，请稍后重试。",
+
+    "mojang_status.service.sessions": "会话服务器",
+    "mojang_status.service.sessions.desc": "多人游戏身份验证",
+    "mojang_status.service.api": "Mojang API",
+    "mojang_status.service.api.desc": "查询玩家或名字",
+    "mojang_status.service.textures": "纹理",
+    "mojang_status.service.textures.desc": "皮肤和披风",
+    "mojang_status.service.website": "Minecraft.net",
+    "mojang_status.service.website.desc": "网站",
+    "mojang_status.service.accounts": "账户",
+    "mojang_status.service.accounts.desc": "账户管理",
+    "mojang_status.service.microsoft": "Microsoft身份验证",
+    "mojang_status.service.microsoft.desc": "使用Microsoft登录（新登录系统）"
+}

--- a/modules/mojang_status/locales/zh_cn.json
+++ b/modules/mojang_status/locales/zh_cn.json
@@ -1,7 +1,7 @@
 {
     "mojang_status.help.desc": "检查 Mojang 和 Minecraft 后端各服务的实时在线情况",
 
-    "mojang_status.message.status": "当前 Mojang 各服务状态：\n${statuses}",
+    "mojang_status.message.status": "当前 Mojang 各服务状态：\n",
     "mojang_status.message.status.each": "${api}：${status}",
     "mojang_status.message.failed": "获取失败，请稍后重试。",
 

--- a/modules/mojang_status/locales/zh_cn.json
+++ b/modules/mojang_status/locales/zh_cn.json
@@ -1,7 +1,7 @@
 {
-    "mojang_status.help.desc": "检查Mojang和Minecraft后端各服务的实时在线情况",
+    "mojang_status.help.desc": "检查 Mojang 和 Minecraft 后端各服务的实时在线情况",
 
-    "mojang_status.message.status": "当前Mojang各服务状态：\n${statuses}",
+    "mojang_status.message.status": "当前 Mojang 各服务状态：\n${statuses}",
     "mojang_status.message.status.each": "${api}：${status}",
     "mojang_status.message.failed": "获取失败，请稍后重试。",
 
@@ -15,6 +15,6 @@
     "mojang_status.service.website.desc": "网站",
     "mojang_status.service.accounts": "账户",
     "mojang_status.service.accounts.desc": "账户管理",
-    "mojang_status.service.microsoft": "Microsoft身份验证",
-    "mojang_status.service.microsoft.desc": "使用Microsoft登录（新登录系统）"
+    "mojang_status.service.microsoft": "Microsoft 身份验证",
+    "mojang_status.service.microsoft.desc": "使用 Microsoft 登录（新登录系统）"
 }


### PR DESCRIPTION
## 描述
<!--请简单描述你的 PR 做了什么，解决了哪些问题。-->
尝试添加一个新模块，用于检测Mojang服务状态。

输入：~mojang_status
输出：当前 Mojang 各服务状态：<...>

使用了来自mcstate.net的第三方API，文档：https://www.mcstate.net/docs#api-mojang-status
此API同IP每分钟可查询20次，之后固定返回429。

Python新手，此前也未参与过项目，如有问题务必指出。

## 变更类型（可多选）
<!--虽然我们不太喜欢用 Conventional Commits，但拜托最好还是选一下。-->
- [x] 新功能
- [ ] 修复
- [ ] 文档 / 样式
- [ ] 重构 / 性能优化
- [ ] 其他

## 风险
<!--如果你的变更涉及以下内容，请如实选择。-->
- [ ] **破坏性变更**（Breaking change）
  - [ ] 必须更改**配置文件**
  - [ ] 必须迁移**数据库**
<!--若必须要更新配置文件 / 数据库版本，请选择以上选项。-->
<!--仅添加新配置项或数据库模型则无需选择。-->

## 相关 Issue
<!--可选，如果有相关的 Issue，请在下方列出。-->
<!--若涉及新功能，请至少先建立一个 Issue 进行讨论。-->
- Close #2091

## 截图 / 演示
<!--可选，可贴上截图或测试日志。-->
<!--文档 / 样式以外的变更建议填写，方便我们测试与验证。-->

## 检查清单
<!--最后一步了！在提交前请再核查以下内容，谢谢茄子。-->
- [x] 我确定我的变更符合[贡献指南](https://github.com/Teahouse-Studios/akari-bot/blob/master/CONTRIBUTING.md)中的项目规范。
- [ ] 我的变更在本地经过了良好的测试，没有产生明显错误。
- [ ] 我确定在此 PR 中披露了可能的破坏性变更。
- [ ] 我已解决所有的合并冲突。
